### PR TITLE
Allow missing  imageIDs

### DIFF
--- a/apis/secscan/v1alpha1/types.go
+++ b/apis/secscan/v1alpha1/types.go
@@ -16,7 +16,7 @@ type Feature struct {
 
 type Vulnerability struct {
 	Name          string `json:"name,omitempty"`
-	NamespaceName string `json:"namenameName,omitempty"`
+	NamespaceName string `json:"namespaceName,omitempty"`
 	Description   string `json:"description,omitempty"`
 	Link          string `json:"link,omitempty"`
 	FixedBy       string `json:"fixedby,omitempty"`

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -2,19 +2,29 @@ package image
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-
 	"k8s.io/api/core/v1"
 )
 
+func generateContainerStatus(name, image, imageID string) v1.ContainerStatus {
+	cs := v1.ContainerStatus{
+		Name:    name,
+		Image:   image,
+		ImageID: imageID,
+	}
+	return cs
+}
+
 var imageTable = []struct {
-	imageID    string
-	host       string
-	namespace  string
-	repository string
-	digest     string
+	imageID string
+
+	expectedHost       string
+	expectedNamespace  string
+	expectedRepository string
+	expectedDigest     string
 }{
 	{
 		"docker-pullable://quay.io/quay/redis@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
@@ -44,19 +54,26 @@ var imageTable = []struct {
 		"redis--test",
 		"sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
 	},
+	{
+		"quay/redis--test@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+		"docker.io",
+		"quay",
+		"redis--test",
+		"sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+	},
 }
 
 func TestParseImageID(t *testing.T) {
 	for _, tt := range imageTable {
 		var image = &Image{
-			Host:       tt.host,
-			Namespace:  tt.namespace,
-			Repository: tt.repository,
-			Digest:     tt.digest,
+			Host:       tt.expectedHost,
+			Namespace:  tt.expectedNamespace,
+			Repository: tt.expectedRepository,
+			Digest:     tt.expectedDigest,
 		}
-		parsedImageID, _ := ParseImageID(tt.imageID)
+		parsedImageID, err := ParseImageID(tt.imageID)
 		if !reflect.DeepEqual(image, parsedImageID) {
-			t.Errorf("Incorrectly parsed %s as %+v", tt.imageID, parsedImageID)
+			t.Errorf("Incorrectly parsed %s as %+v: %s", tt.imageID, parsedImageID, err)
 		}
 	}
 }
@@ -66,8 +83,6 @@ var containerStatusTable = []struct {
 	name    string
 	image   string
 	imageID string
-
-	// Full image strings (docker)
 
 	// Expected values
 	containername string
@@ -149,26 +164,44 @@ func TestParseContainerStatus(t *testing.T) {
 	}
 }
 
-func TestStringRepresentations(t *testing.T) {
-	for _, tt := range containerStatusTable {
-		var image = &Image{
-			ContainerName: tt.containername,
-			Host:          tt.host,
-			Namespace:     tt.namespace,
-			Repository:    tt.repository,
-			Digest:        tt.digest,
-			Tag:           tt.tag,
-		}
-		assert.Equal(t, tt.image, image.String())
-		assert.Equal(t, tt.imageID, image.IDString())
-	}
+var imageIDTable = []struct {
+	imageID        string
+	tag            string
+	expectedString string
+}{
+	{
+		imageID:        "docker-pullable://quay.io/quay/redis@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+		tag:            "testTag",
+		expectedString: "quay.io/quay/redis:testTag",
+	},
+	{
+		imageID:        "docker-pullable://nginx@sha256:0d71ff22db29a08ac7399d1b35b0311c5b0cbe68d878993718275758811f652a",
+		tag:            "testTag",
+		expectedString: "nginx:testTag",
+	},
+	{
+		imageID:        "docker-pullable://quay/redis@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+		tag:            "testTag",
+		expectedString: "quay/redis:testTag",
+	},
+	{
+		imageID:        "docker-pullable://quay/redis--test@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+		tag:            "testTag",
+		expectedString: "quay/redis--test:testTag",
+	},
+	{
+		imageID:        "quay.io/quay/redis@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
+		tag:            "testTag",
+		expectedString: "quay.io/quay/redis:testTag",
+	},
 }
 
-func generateContainerStatus(name, image, imageID string) v1.ContainerStatus {
-	cs := v1.ContainerStatus{
-		Name:    name,
-		Image:   image,
-		ImageID: imageID,
+func TestStringIDRepresentations(t *testing.T) {
+	for _, tt := range imageIDTable {
+		image, _ := ParseImageID(tt.imageID)
+		image.Tag = tt.tag
+		expectedImageID := strings.TrimPrefix(tt.imageID, "docker-pullable://")
+		assert.Equal(t, expectedImageID, image.IDString())
+		assert.Equal(t, tt.expectedString, image.String())
 	}
-	return cs
 }

--- a/image/image_test.go
+++ b/image/image_test.go
@@ -61,6 +61,13 @@ var imageTable = []struct {
 		"redis--test",
 		"sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
 	},
+	{
+		"docker-pullable://quay.io/alecmerdler/bbb@sha256:24c6258b99cd427d0c3003e2878159de269f96c4ffbdeceaf9373ea3a31866b3",
+		"quay.io",
+		"alecmerdler",
+		"bbb",
+		"sha256:24c6258b99cd427d0c3003e2878159de269f96c4ffbdeceaf9373ea3a31866b3",
+	},
 }
 
 func TestParseImageID(t *testing.T) {
@@ -140,6 +147,18 @@ var containerStatusTable = []struct {
 		"sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
 		"latest",
 	},
+	{
+		"bbb",
+		"quay.io/alecmerdler/bbb:scrape",
+		"docker-pullable://quay.io/alecmerdler/bbb@sha256:24c6258b99cd427d0c3003e2878159de269f96c4ffbdeceaf9373ea3a31866b3",
+
+		"bbb",
+		"quay.io",
+		"alecmerdler",
+		"bbb",
+		"sha256:24c6258b99cd427d0c3003e2878159de269f96c4ffbdeceaf9373ea3a31866b3",
+		"scrape",
+	},
 }
 
 func TestParseContainerStatus(t *testing.T) {
@@ -193,6 +212,11 @@ var imageIDTable = []struct {
 		imageID:        "quay.io/quay/redis@sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e",
 		tag:            "testTag",
 		expectedString: "quay.io/quay/redis:testTag",
+	},
+	{
+		imageID:        "docker-pullable://quay.io/alecmerdler/bbb@sha256:24c6258b99cd427d0c3003e2878159de269f96c4ffbdeceaf9373ea3a31866b3",
+		tag:            "scrape",
+		expectedString: "quay.io/alecmerdler/bbb:scrape",
 	},
 }
 


### PR DESCRIPTION
Allow missing `docker-pullable://` in ImageID field since it seems to be missing in Openshift clusters.

https://github.com/kubernetes/kubernetes/blob/master/pkg/kubelet/dockershim/naming.go#L55