### PR TITLE
Remove CVEs from Labels on `ImageManifestVuln`

### DIFF
--- a/labeller/manifest.go
+++ b/labeller/manifest.go
@@ -126,9 +126,6 @@ func buildImageManifestVuln(namespace, image, manifestDigest string, layer *secs
 			default:
 				return nil, fmt.Errorf("Unknown severity %s: not one of %v", vulnerability.Severity, secscan.Severities)
 			}
-
-			label := labelName(labelPrefix, vulnerability.Name)
-			labels[label] = vulnerability.Severity
 		}
 
 		if vulnCount > 0 {


### PR DESCRIPTION
### Description

Unfortunately, the names of some CVEs violate the regex for `metadata.labels`. We will need to find a different way for users to query the Kubernetes API for vulnerabilities present on the cluster.

Fixes https://jira.coreos.com/browse/QUAY-2119