### PR TITLE
Uses a well-known endpoint to get the security scanning endpoint

### DIFF
--- a/cmd/security-labeller/main.go
+++ b/cmd/security-labeller/main.go
@@ -45,6 +45,7 @@ func main() {
 	scannerToken := flag.String("scannerToken", "", "Scanner bearer token.")
 	scannerVersion := flag.Int("scannerVersion", 1, "Scanner api version.")
 	scannerType := flag.String("scannerType", "quay", "Scanner type.")
+	wellknownEndpoint := flag.String("wellknownEndpoint", ".well-known/app-capabilities", "Wellknown endpoint")
 
 	flagKubeConfigPath := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
 	flag.Parse()
@@ -62,10 +63,11 @@ func main() {
 		}
 	} else {
 		cfg = &labeller.Config{
-			Namespaces:     namespaces,
-			Interval:       interval,
-			LabelPrefix:    *labelPrefix,
-			PrometheusAddr: *promAddr,
+			Namespaces:        namespaces,
+			Interval:          interval,
+			LabelPrefix:       *labelPrefix,
+			PrometheusAddr:    *promAddr,
+			WellknownEndpoint: *wellknownEndpoint,
 			SecurityScanner: labeller.SecurityScannerOptions{
 				*scannerHost,
 				*scannerToken,

--- a/example-config.yaml
+++ b/example-config.yaml
@@ -1,11 +1,7 @@
 securitylabeller:
+  wellknownEndpoint: ".well-known/app-capabilities"
   prometheusAddr: ":8081"
   interval: 15s
   labelPrefix: secscan
   namespaces:
     - test
-  securityScanner:
-    host: "https://quay.io"
-    token: ""
-    apiVersion: 1
-    type: Quay

--- a/labeller/config.go
+++ b/labeller/config.go
@@ -9,11 +9,12 @@ import (
 )
 
 type Config struct {
-	Namespaces      []string               `yaml:"namespaces"`
-	Interval        time.Duration          `yaml:"interval"`
-	SecurityScanner SecurityScannerOptions `yaml:"securityScanner"`
-	LabelPrefix     string                 `yaml:"labelPrefix"`
-	PrometheusAddr  string                 `yaml:"prometheusAddr"`
+	Namespaces        []string               `yaml:"namespaces"`
+	Interval          time.Duration          `yaml:"interval"`
+	SecurityScanner   SecurityScannerOptions `yaml:"securityScanner"`
+	LabelPrefix       string                 `yaml:"labelPrefix"`
+	PrometheusAddr    string                 `yaml:"prometheusAddr"`
+	WellknownEndpoint string                 `yaml:"wellknownEndpoint"`
 }
 
 type SecurityScannerOptions struct {

--- a/secscan/client.go
+++ b/secscan/client.go
@@ -1,0 +1,67 @@
+package secscan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/quay/container-security-operator/image"
+	"github.com/quay/container-security-operator/secscan/rest"
+)
+
+type Client struct{}
+
+func NewClient() (*Client, error) {
+	c := &Client{}
+	return c, nil
+}
+
+func (c *Client) Wellknown(host, endpoint string) (WellknownInterface, error) {
+	wellknownClient, err := NewWellknownClient(host, endpoint)
+	if err != nil {
+		return nil, err
+	}
+	return wellknownClient, nil
+}
+
+func (c *Client) GetLayerDataFromTemplate(template string, image *image.Image, features, vulnerabilities bool) (*Layer, error) {
+	replacer := strings.NewReplacer("{namespace}", image.Namespace, "{reponame}", image.Repository, "{digest}", image.Digest)
+	requestURI := replacer.Replace(template)
+	url, err := url.ParseRequestURI(requestURI)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse security manifest URL %s: %w", requestURI, err)
+	}
+
+	req := rest.NewRequest(http.DefaultClient, "GET", url, "")
+	req = req.SetParam("features", strconv.FormatBool(features))
+	req = req.SetParam("vulnerabilities", strconv.FormatBool(vulnerabilities))
+	resp, err := req.Do()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Request returned non-200 response: %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	var securityResponse Response
+	err = json.Unmarshal(body, &securityResponse)
+	if err != nil {
+		return nil, err
+	}
+
+	if securityResponse.Status != "scanned" {
+		return nil, fmt.Errorf("Image not scanned: %s", securityResponse.Status)
+	}
+
+	return &securityResponse.Data.Layer, nil
+}

--- a/secscan/rest/request.go
+++ b/secscan/rest/request.go
@@ -17,9 +17,6 @@ type Request struct {
 	subpath    string
 	params     url.Values
 	headers    http.Header
-
-	// Quay specific resources
-	// ...
 }
 
 func NewRequest(client HTTPClient, verb string, baseURL *url.URL, versionedAPIPath string) *Request {

--- a/secscan/types.go
+++ b/secscan/types.go
@@ -9,9 +9,15 @@ import (
 	"github.com/quay/container-security-operator/image"
 )
 
-type Client interface {
-	Ping() bool
-	GetLayerData(image *image.Image, features, vulnerabilities bool) (*Layer, error)
+type Interface interface {
+	Wellknown(host, endpoint string) (WellknownInterface, error)
+	GetLayerDataFromTemplate(manifestTemplate string, image *image.Image, features, vulnerabilities bool) (*Layer, error)
+}
+
+type WellknownInterface interface {
+	ViewImageTemplate() (string, error)
+	ManifestSecurityTemplate() (string, error)
+	ImageSecurityTemplate() (string, error)
 }
 
 type Response struct {

--- a/secscan/wellknown.go
+++ b/secscan/wellknown.go
@@ -1,0 +1,120 @@
+package secscan
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/quay/container-security-operator/secscan/rest"
+)
+
+const (
+	wellKnownEndpoint = "/.well-known/app-capabilities"
+
+	viewImageKeySuffix        = "view-image"
+	manifestSecurityKeySuffix = "manifest-security"
+	imageSecurityKeySuffix    = "image-security"
+
+	urlTemplateKey     = "url-template"
+	restApiTemplateKey = "rest-api-template"
+)
+
+type AppCapabilities struct {
+	AppName      string              `json:"appName"`
+	Capabilities map[string]Template `json:"capabilities"`
+}
+
+type Template map[string]string
+
+// Generate the template key from the given host and key suffix
+// e.g. io.quay.manifest-security
+func appCapabilityKey(host, keySuffix string) string {
+	split := strings.Split(host, ".")
+	for i := len(split)/2 - 1; i >= 0; i-- {
+		opp := len(split) - 1 - i
+		split[i], split[opp] = split[opp], split[i]
+	}
+
+	split = append(split, keySuffix)
+	return strings.Join(split, ".")
+}
+
+type WellknownClient struct {
+	host              string
+	wellKnownEndpoint string
+	appCapabilities   *AppCapabilities
+}
+
+func (wc *WellknownClient) RequestBaseURI() string {
+	return "https://" + wc.host
+}
+
+func NewWellknownClient(host, wellKnownEndpoint string) (*WellknownClient, error) {
+	c := &WellknownClient{
+		host:              host,
+		wellKnownEndpoint: wellKnownEndpoint,
+		appCapabilities:   &AppCapabilities{},
+	}
+
+	baseUrl, err := url.ParseRequestURI(c.RequestBaseURI())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse well-known URL %s: %w", c.RequestBaseURI(), err)
+	}
+
+	req := rest.NewRequest(http.DefaultClient, "GET", baseUrl, "")
+	req = req.Path(c.wellKnownEndpoint)
+
+	resp, err := req.Do()
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("Request returned non-200 response: %s", resp.Status)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(body, c.appCapabilities)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+func (wc *WellknownClient) ViewImageTemplate() (string, error) {
+	key := appCapabilityKey(wc.host, viewImageKeySuffix)
+	viewImage := wc.appCapabilities.Capabilities[key]
+	urlTemplate := viewImage[urlTemplateKey]
+	if len(urlTemplate) == 0 {
+		return urlTemplate, fmt.Errorf("No view image capabilities")
+	}
+	return urlTemplate, nil
+}
+
+func (wc *WellknownClient) ManifestSecurityTemplate() (string, error) {
+	key := appCapabilityKey(wc.host, manifestSecurityKeySuffix)
+	manifestSecurity := wc.appCapabilities.Capabilities[key]
+	restApiTemplate := manifestSecurity[restApiTemplateKey]
+	if len(restApiTemplate) == 0 {
+		return restApiTemplate, fmt.Errorf("No manifest security capabilities")
+	}
+	return restApiTemplate, nil
+}
+
+func (wc *WellknownClient) ImageSecurityTemplate() (string, error) {
+	key := appCapabilityKey(wc.host, imageSecurityKeySuffix)
+	imageSecurity := wc.appCapabilities.Capabilities[key]
+	restApiTemplate := imageSecurity[restApiTemplateKey]
+	if len(restApiTemplate) == 0 {
+		return restApiTemplate, fmt.Errorf("No image security capabilities")
+	}
+	return restApiTemplate, nil
+}


### PR DESCRIPTION
Query a `.well-known` endpoint implemented by the security scanner to get the API endpoint to use.