### PR TITLE
Fix Docker Container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Binaries for programs and plugins
+bin/
 *.exe
 *.dll
 *.so
@@ -9,8 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
-
-# Project-local glide cache, RE: https://github.com/Masterminds/glide/issues/736
-.glide/
 
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,10 +15,9 @@ COPY prometheus/ prometheus/
 COPY secscan/ secscan/
 COPY Makefile Makefile
 
-RUN make build
-
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 make build
 
 FROM alpine:3.10
 WORKDIR /
-COPY --from=builder /workspace/bin/security-labeller .
-ENTRYPOINT ["/security-labeller"]
+COPY --from=builder /workspace/bin/security-labeller /bin/security-labeller
+ENTRYPOINT ["/bin/security-labeller"]


### PR DESCRIPTION
### Description

Fixes the `standard_init_linux.go:211: exec user process caused "no such file or directory"` issue caused when running `docker run` on the built container. 