### PR TITLE
Fix manifest update

### DIFF
--- a/labeller/labeller.go
+++ b/labeller/labeller.go
@@ -334,6 +334,13 @@ func (l *Labeller) SecurityLabelPod(key string) error {
 			return err
 		}
 
+		// Garbage collect unreferenced manifests and remove dangling pods from existing manifests
+		level.Info(l.logger).Log("msg", "Garbage collecting unreferenced ImageManifestVulns", "key", key)
+		if err := garbageCollectManifests(podClient, imageManifestVulnClient); err != nil {
+			level.Error(l.logger).Log("msg", "Failed to garbage collect unreferenced ImageManifestVulns", "err", err)
+			return fmt.Errorf("Failed to garbage collect unreferenced ImageManifestVulns: %w", err)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
- Fixes manifest' status update when removing affected pods
- Check for nil labal map before adding a value to manifest labels
- Call garbage collection on the deletion event.
- Extra test