### PR TITLE
Remove Unused Config Fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,7 @@ securitylabeller:
   labelPrefix: secscan # Security labels' "namespace"
   namespaces: # List of namespaces to label in the cluster
     - default
-    - dev
-  securityScanner:
-    host: "https://quay.io"
-    apiVersion: 1
-    type: "Quay"
-    
+    - dev  
 ```
 
 ## Features

--- a/cmd/security-labeller/main.go
+++ b/cmd/security-labeller/main.go
@@ -43,10 +43,6 @@ func main() {
 	resyncInterval := flag.String("resyncInterval", "30m", "Controller resync interval.")
 	resyncThreshold := flag.String("resyncThreshold", "1h", "Minimum threshold to resync ImageManifestVulns.")
 	labelPrefix := flag.String("labelPrefix", "secscan", "CR label prefix.")
-	scannerHost := flag.String("scannerHost", "https://quay.io", "Scanner endpoint.")
-	scannerToken := flag.String("scannerToken", "", "Scanner bearer token.")
-	scannerVersion := flag.Int("scannerVersion", 1, "Scanner api version.")
-	scannerType := flag.String("scannerType", "quay", "Scanner type.")
 	wellknownEndpoint := flag.String("wellknownEndpoint", ".well-known/app-capabilities", "Wellknown endpoint")
 
 	flagKubeConfigPath := flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
@@ -84,12 +80,6 @@ func main() {
 			LabelPrefix:       *labelPrefix,
 			PrometheusAddr:    *promAddr,
 			WellknownEndpoint: *wellknownEndpoint,
-			SecurityScanner: labeller.SecurityScannerOptions{
-				*scannerHost,
-				*scannerToken,
-				*scannerVersion,
-				*scannerType,
-			},
 		}
 	}
 

--- a/labeller/config.go
+++ b/labeller/config.go
@@ -9,20 +9,12 @@ import (
 )
 
 type Config struct {
-	Namespaces        []string               `yaml:"namespaces"`
-	Interval          time.Duration          `yaml:"interval"`
-	ResyncThreshold   time.Duration          `yaml:"resyncThreshold"`
-	SecurityScanner   SecurityScannerOptions `yaml:"securityScanner"`
-	LabelPrefix       string                 `yaml:"labelPrefix"`
-	PrometheusAddr    string                 `yaml:"prometheusAddr"`
-	WellknownEndpoint string                 `yaml:"wellknownEndpoint"`
-}
-
-type SecurityScannerOptions struct {
-	Host       string `yaml:"host"`
-	Token      string `yaml:"token"`
-	APIVersion int    `yaml:"apiVersion"`
-	Type       string `yaml:"type"`
+	Namespaces        []string      `yaml:"namespaces"`
+	Interval          time.Duration `yaml:"interval"`
+	ResyncThreshold   time.Duration `yaml:"resyncThreshold"`
+	LabelPrefix       string        `yaml:"labelPrefix"`
+	PrometheusAddr    string        `yaml:"prometheusAddr"`
+	WellknownEndpoint string        `yaml:"wellknownEndpoint"`
 }
 
 // YAML configuration with all SecurityLabeller configuration under top-level "security-labeller" key


### PR DESCRIPTION
### Description

The `securityScanner` section of the config is irrelevant and unused; we simply use the host of the image we are scanning.

Addresses https://issues.redhat.com/browse/PROJQUAY-51