### PR TITLE
More CLI Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,17 @@ $ kubectl get packagemanifest container-security-operator
 
 ### Using kubectl
 
-Check if a pod has any vulnerability, and list the CVEs, if any:
-
+Get a list of all the pods affected by vulnerable images detected by the Operator:
 ```sh
-$ kubectl get imagemanifestvulns.secscan.quay.redhat.com --selector=test/redis-567899f7cc-tdl2g -o jsonpath='{.items[*].spec.features[*].vulnerabilities[*].name}'
+$ kubectl get imagemanifestvuln --all-namespaces -o json | jq '.items[].status.affectedPods' | jq 'keys' | jq 'unique'
+```
+
+Get a list of all detected CVEs in pods running on the cluster:
+```sh
+$ kubectl get imagemanifestvuln --all-namespaces -o json | jq '[.items[].spec.features[].vulnerabilities[].name'] | jq 'unique'
+```
+
+Check if a pod has any vulnerability, and list the CVEs, if any:
+```sh
+$ kubectl get imagemanifestvulns.secscan.quay.redhat.com --selector=<namespace>/<pod-name> -o jsonpath='{.items[*].spec.features[*].vulnerabilities[*].name}'
 ```

--- a/deploy/cso.catalogsource.yaml
+++ b/deploy/cso.catalogsource.yaml
@@ -4,4 +4,4 @@ metadata:
   name: container-security-operator
 spec:
   sourceType: grpc
-  image: quay.io/quay/cso-catalog@sha256:d9a5f9f130a580e929a6fc123d2b9a10c00e50bb3d940f37204bfab5772c46af
+  image: quay.io/quay/cso-catalog@sha256:b22225d196d83108733c16b4d9918308ffa18686581970dcb8284f1827c4686d


### PR DESCRIPTION
### Description

Adds more CLI examples. Also fixes the `cso.catalogsource.yaml` to use the correct image containing `v1.0.1`. Also adds `alm-examples` (even though our Operands are intended to be read-only).