### PR TITLE
Add Missing `version` to CRDs

### DIFF
--- a/deploy/manifests/container-security-operator/1.0.3/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
+++ b/deploy/manifests/container-security-operator/1.0.3/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: imagemanifestvulns.secscan.quay.redhat.com
 spec:
   group: secscan.quay.redhat.com
+  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true

--- a/deploy/manifests/container-security-operator/1.0.4/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
+++ b/deploy/manifests/container-security-operator/1.0.4/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
@@ -4,6 +4,7 @@ metadata:
   name: imagemanifestvulns.secscan.quay.redhat.com
 spec:
   group: secscan.quay.redhat.com
+  version: v1alpha1
   versions:
     - name: v1alpha1
       served: true


### PR DESCRIPTION
### Description

Required by `operator-courier` (despite being deprecated in CRD spec).