### PR TITLE
Migrating crd v1.0.6 to apiextensions.k8s.io/v1

### DIFF
--- a/deploy/manifests/container-security-operator/1.0.6/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
+++ b/deploy/manifests/container-security-operator/1.0.6/imagemanifestvulns.secscan.quay.redhat.com.crd.yaml
@@ -1,14 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: imagemanifestvulns.secscan.quay.redhat.com
 spec:
   group: secscan.quay.redhat.com
-  version: v1alpha1
-  versions:
-    - name: v1alpha1
-      served: true
-      storage: true
   scope: Namespaced
   names:
     plural: imagemanifestvulns
@@ -18,104 +13,108 @@ spec:
     shortNames:
       - vuln
   preserveUnknownFields: false
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      type: object
-      required: ["spec"]
-      properties:
-        spec:
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
           type: object
+          required: ["spec"]
           properties:
-            image:
-              type: string
-              minLength: 1
-            manifest:
-              type: string
-              minLength: 1
-            namespaceName:
-              type: string
-              minLength: 1
-            features:
-              type: array
-              items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                    minLength: 1
-                  versionformat:
-                    type: string
-                    minLength: 1
-                  namespaceName:
-                    type: string
-                    minLength: 1
-                  version:
-                    type: string
-                    minLength: 1
-                  vulnerabilities:
+            spec:
+              type: object
+              properties:
+                image:
+                  type: string
+                  minLength: 1
+                manifest:
+                  type: string
+                  minLength: 1
+                namespaceName:
+                  type: string
+                  minLength: 1
+                features:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                        minLength: 1
+                      versionformat:
+                        type: string
+                        minLength: 1
+                      namespaceName:
+                        type: string
+                        minLength: 1
+                      version:
+                        type: string
+                        minLength: 1
+                      vulnerabilities:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                              minLength: 1
+                            namespaceName:
+                              type: string
+                              minLength: 1
+                            description:
+                              type: string
+                              minLength: 1
+                            link:
+                              type: string
+                              minLength: 1
+                            fixedby:
+                              type: string
+                              minLength: 1
+                            severity:
+                              type: string
+                              minLength: 1
+                            metadata:
+                              type: string
+                              minLength: 1
+            status:
+              type: object
+              properties:
+                lastUpdate:
+                  type: string
+                  minLength: 1
+                highestSeverity:
+                  type: string
+                  minLength: 1
+                unknownCount:
+                  type: integer
+                  minimum: 0
+                negligibleCount:
+                  type: integer
+                  minimum: 0
+                lowCount:
+                  type: integer
+                  minimum: 0
+                mediumCount:
+                  type: integer
+                  minimum: 0
+                highCount:
+                  type: integer
+                  minimum: 0
+                criticalCount:
+                  type: integer
+                  minimum: 0
+                defcon1Count:
+                  type: integer
+                  minimum: 0
+                fixableCount:
+                  type: integer
+                  minimum: 0
+                affectedPods:
+                  type: object
+                  additionalProperties:
                     type: array
                     items:
-                      type: object
-                      properties:
-                        name:
-                          type: string
-                          minLength: 1
-                        namespaceName:
-                          type: string
-                          minLength: 1
-                        description:
-                          type: string
-                          minLength: 1
-                        link:
-                          type: string
-                          minLength: 1
-                        fixedby:
-                          type: string
-                          minLength: 1
-                        severity:
-                          type: string
-                          minLength: 1
-                        metadata:
-                          type: string
-                          minLength: 1
-        status:
-          type: object
-          properties:
-            lastUpdate:
-              type: string
-              minLength: 1
-            highestSeverity:
-              type: string
-              minLength: 1
-            unknownCount:
-              type: integer
-              minimum: 0
-            negligibleCount:
-              type: integer
-              minimum: 0
-            lowCount:
-              type: integer
-              minimum: 0
-            mediumCount:
-              type: integer
-              minimum: 0
-            highCount:
-              type: integer
-              minimum: 0
-            criticalCount:
-              type: integer
-              minimum: 0
-            defcon1Count:
-              type: integer
-              minimum: 0
-            fixableCount:
-              type: integer
-              minimum: 0
-            affectedPods:
-              type: object
-              additionalProperties:
-                type: array
-                items:
-                  type: string
+                      type: string


### PR DESCRIPTION
This commit migrates v1.0.6 of vuln CRD from extenstions v1beta1 to v1.