### PR TITLE
proxy: mount cluster trusted ca (PROJQUAY-2153)

### DIFF
--- a/bundle/manifests/container-security-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-security-operator.clusterserviceversion.yaml
@@ -72,10 +72,14 @@ spec:
                 name: container-security-operator
               serviceAccountName: container-security-operator
               volumes:
-                - name: extra-certs
-                  secret:
-                    optional: true
-                    secretName: container-security-operator-extra-certs
+              - name: extra-certs
+                projected:
+                  sources:
+                  - configMap:
+                      name: cso-cluster-trusted-ca
+                  - secret:
+                      optional: true
+                      name: container-security-operator-extra-certs
       permissions:
       - rules:
         - apiGroups:

--- a/bundle/manifests/cso-cluster-trusted-ca.configmap.yaml
+++ b/bundle/manifests/cso-cluster-trusted-ca.configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: cso-cluster-trusted-ca
+data: {}


### PR DESCRIPTION
Requesting and mounting the cluster trusted ca inside the extra ca
directory. This is necessary to properly support proxy as its ca is
part of the cluster trust bundle.