### PR TITLE
adhoc: fixing missing ctx and tests race condition

### DIFF
--- a/labeller/labeller.go
+++ b/labeller/labeller.go
@@ -386,7 +386,7 @@ func (l *Labeller) Reconcile(ctx context.Context, key string) error {
 	}
 
 	defaultSecretClient := l.kclient.CoreV1().Secrets("openshift-config")
-	clusterAuths, err := image.ParsePullSecret(defaultSecretClient, "pull-secret")
+	clusterAuths, err := image.ParsePullSecret(ctx, defaultSecretClient, "pull-secret")
 	if err != nil {
 		level.Error(l.logger).Log("msg", "fail to process global pull secret", "err", err)
 		clusterAuths = &image.DockerConfigJson{Auths: map[string]image.DockerAuth{}}

--- a/labeller/manifest_test.go
+++ b/labeller/manifest_test.go
@@ -204,12 +204,16 @@ func (c *testClient) getManifest(namespace, name string, getOptions metav1.GetOp
 
 func (c *testClient) updateManifestStatus(manifest *secscanv1alpha1.ImageManifestVuln) (*secscanv1alpha1.ImageManifestVuln, error) {
 	ctx := context.Background()
-	return c.imageManifestVulnsClient(manifest.ObjectMeta.Namespace).UpdateStatus(ctx, manifest, metav1.UpdateOptions{})
+	man, err := c.imageManifestVulnsClient(manifest.ObjectMeta.Namespace).UpdateStatus(ctx, manifest, metav1.UpdateOptions{})
+	time.Sleep(time.Second)
+	return man, err
 }
 
 func (c *testClient) deletePod(namespace, name string, deleteOptions metav1.DeleteOptions) error {
 	ctx := context.Background()
-	return c.podsClient(namespace).Delete(ctx, name, deleteOptions)
+	err := c.podsClient(namespace).Delete(ctx, name, deleteOptions)
+	time.Sleep(time.Second)
+	return err
 }
 
 func (c *testClient) updatePodStatus(pod *corev1.Pod) (*corev1.Pod, error) {
@@ -223,6 +227,7 @@ func (c *testClient) createPod(pod *corev1.Pod) (*corev1.Pod, error) {
 	if err != nil {
 		return nil, err
 	}
+	time.Sleep(time.Second)
 	return res, err
 }
 


### PR DESCRIPTION
Due to lack of a proper CI the previous commit ended up being merged in
a botched way. This one addresses a missing context.Context and adds
some sleep to avoid race conditions during test executions.