### PR TITLE
ppc64le/multi-arch support for container-security-operator (PROJQUAY-5584)

### DIFF
--- a/.github/workflows/build-and-publish.yaml
+++ b/.github/workflows/build-and-publish.yaml
@@ -1,0 +1,41 @@
+name: build-and-publish
+on: [push]
+jobs:
+  build-and-publish:
+    name: Build and Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Install opm from OpenShift Mirror
+        uses: redhat-actions/openshift-tools-installer@v1
+        with:
+          opm: "latest"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      
+      - name: Install yq
+        env:
+          VERSION: v4.14.2
+          BINARY: yq_linux_amd64
+        run: |
+          wget https://github.com/mikefarah/yq/releases/download/${VERSION}/${BINARY} -O /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+      
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - id: build-and-publish
+        run: ./hack/build.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM golang:1.17 as builder
+FROM --platform=$BUILDPLATFORM golang:1.17 as builder
 
+ARG TARGETOS TARGETARCH
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -15,7 +16,7 @@ COPY prometheus/ prometheus/
 COPY secscan/ secscan/
 COPY Makefile Makefile
 
-RUN CGO_ENABLED=0 GOOS=linux make build
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH make build
 
 FROM alpine:3.10
 WORKDIR /


### PR DESCRIPTION
Updated Dockerfile and build.sh to support multi-arch image builds for amd64, s390x, and ppc64le.
`build.sh` builds multi-arch operator and operator-bundle image. Then builds a single-arch image bundled by proper operator-bundle image before manifesting into one multi-arch operator-index image.
Running `./hack/build.sh` and `./hack/deploy.sh` will build proper multi-arch images and deploy the operator based on cluster arch.