### PR TITLE
chore: Use default limit for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,3 @@ updates:
       interval: weekly
     assignees:
       - dmage
-    open-pull-requests-limit: 1


### PR DESCRIPTION
The default limit is 5 and it'll work well for this repo.