### PR TITLE
chore: updated labels in CSV for z/power support

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -12,8 +12,10 @@
 # REQUIREMENTS:
 #  * a valid login session to a container registry.
 #  * `docker`
+#  * `jq`
 #  * `yq`
 #  * `opm`
+#  * `skopeo`
 #
 # NOTE: this script will modify the following files:
 #  - bundle/manifests/container-security-operator.clusterserviceversion.yaml
@@ -72,6 +74,7 @@ yq eval -i '
 	.metadata.name = strenv(OPERATOR_NAME) |
 	.metadata.annotations.version = strenv(TAG) |
 	.metadata.annotations.containerImage = strenv(OPERATOR_DIGEST) |
+	.metadata.labels += {"operatorframework.io/arch.amd64": "supported", "operatorframework.io/arch.s390x": "supported", "operatorframework.io/arch.ppc64le": "supported", "operatorframework.io/os.linux": "supported"} |
 	del(.spec.replaces) |
 	.spec.install.spec.deployments[0].name = strenv(OPERATOR_NAME) |
 	.spec.install.spec.deployments[0].spec.template.spec.containers[0].image = strenv(OPERATOR_DIGEST)


### PR DESCRIPTION
# Description
Added labels for both **s390x** and **ppc64le** in **CSV** file as discussed in [thread](https://ibm-redhat-collab.slack.com/archives/C050GAV39DG/p1688391000587939)

## Tests that have been done

- Tested by deploying the operator in the OCP 

## Changes that have been done

- Added labels for `arch.amd64`, `arch.s390x`, `arch.ppc64le` and `os.linux` as supported