### PR TITLE
fetching digest from image field when using cri-o (PROJQUAY-6512)

### DIFF
--- a/image/image_test.go
+++ b/image/image_test.go
@@ -131,6 +131,20 @@ var containerStatusTable = []struct {
 }{
 	{
 		"my-test-repository",
+		"QUAY:443/my-test-namespace/my-test-repository@sha256:c549c6151dd8f4098fd02198913c0f6c55b240b156475588257f19d57e7b1fba",
+		"cf879a45faaacd2806705321f157c4c77682c7599589fed65d80f19bb61615a6",
+
+		"my-test-repository",
+		"QUAY:443",
+		"my-test-namespace",
+		"my-test-repository",
+		"sha256:c549c6151dd8f4098fd02198913c0f6c55b240b156475588257f19d57e7b1fba",
+		"",
+
+		nil,
+	},
+	{
+		"my-test-repository",
 		"QUAY:443/my-test-namespace/my-test-repository:latest",
 		"docker-pullable://QUAY:443/my-test-namespace/my-test-repository@sha256:c549c6151dd8f4098fd02198913c0f6c55b240b156475588257f19d57e7b1fba",
 		"my-test-repository",
@@ -238,6 +252,20 @@ var containerStatusTable = []struct {
 		"",
 
 		fmt.Errorf("Invalid imageID format: %s", "sha256:94033a42da840b970fd9d2b04dae5fec56add2714ca674a758d030ce5acba27e"),
+	},
+	{
+		"my-test-repository",
+		"QUAY:443/my-test-namespace/my-test-repository:latest",
+		"cf879a45faaacd2806705321f157c4c77682c7599589fed65d80f19bb61615a6",
+
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+
+		fmt.Errorf("both image and imageID status fields do not contain digest: %s", "QUAY:443/my-test-namespace/my-test-repository:latest"),
 	},
 }
 

--- a/labeller/labeller.go
+++ b/labeller/labeller.go
@@ -403,7 +403,7 @@ func (l *Labeller) scan(ctx context.Context, pod *corev1.Pod, img *image.Image, 
 			return fmt.Errorf("error updating image manifest vuln: %w", err)
 		}
 
-		level.Info(l.logger).Log("msg", "image manifest vuln creted", "image", img.String())
+		level.Info(l.logger).Log("msg", "image manifest vuln created", "image", img.String())
 		return nil
 	}
 
@@ -523,7 +523,7 @@ func (l *Labeller) Reconcile(ctx context.Context, key string) error {
 	for _, containerStatus := range pod.Status.ContainerStatuses {
 		img, err := image.ParseContainerStatus(containerStatus)
 		if err != nil {
-			level.Error(l.logger).Log("msg", "Error parsing imageID", "imageID", containerStatus.ImageID)
+			level.Error(l.logger).Log("msg", "Error parsing imageID", "err", err)
 			continue
 		}
 


### PR DESCRIPTION
As of OCP 4.15 the cri-o runtime now replaces the `pod.status.imageID` field with an internal cri-o ID instead of the resolved digest. This prevents CSO retrieving scan results since it's unable to fetch a digest for the resolved image. This change checks for a cri-o image ID and in which case will use the `pod.status.image` field. This allows images referenced by digest to be scanned. Images referenced by tag will not be able to be scanned.