### PR TITLE
feat: Add user agent to CSO (PROJQUAY-7472)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.20 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20 AS builder
 
 ARG TARGETOS TARGETARCH
 WORKDIR /workspace

--- a/bundle/manifests/container-security-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-security-operator.clusterserviceversion.yaml
@@ -7,6 +7,7 @@ metadata:
     containerImage: quay.io/quay/container-security-operator@sha256:6eefeaee910251ba26c825746d11ae166a9781aeace5455b2766d26298911f13
     createdAt: 2020-04-13 00:00:00
     description: Identify image vulnerabilities in Kubernetes pods
+    quay-version: v3.11.0
     repository: https://github.com/quay/container-security-operator
     tectonic-visibility: ocs
     features.operators.openshift.io/disconnected: "false"
@@ -76,6 +77,10 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: QUAY_VERSION
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['quay-version']
                 volumeMounts:
                   - name: extra-certs
                     readOnly: true

--- a/cmd/security-labeller/main.go
+++ b/cmd/security-labeller/main.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"flag"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/signal"
@@ -125,7 +124,7 @@ func handleCerts(insecure bool, extraCerts string) error {
 		if info.IsDir() {
 			return nil
 		}
-		certs, err := ioutil.ReadFile(path)
+		certs, err := os.ReadFile(path)
 
 		if err != nil {
 			return nil

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	github.com/go-kit/kit v0.12.0
+	github.com/go-kit/log v0.2.1
 	github.com/openshift/client-go v0.0.0-20230626133714-296133fbf75e
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.16.0
@@ -21,7 +22,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.9.0 // indirect
 	github.com/evanphx/json-patch v5.6.0+incompatible // indirect
-	github.com/go-kit/log v0.2.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/go-logr/logr v1.2.4 // indirect
 	github.com/go-openapi/jsonpointer v0.19.6 // indirect

--- a/labeller/config.go
+++ b/labeller/config.go
@@ -1,7 +1,7 @@
 package labeller
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"time"
 
@@ -33,7 +33,7 @@ func LoadConfig(cfgPath string) (*Config, error) {
 	}
 	defer f.Close()
 
-	d, err := ioutil.ReadAll(f)
+	d, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/labeller/labeller_test.go
+++ b/labeller/labeller_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	log "github.com/go-kit/kit/log"
+	log "github.com/go-kit/log"
 	"github.com/stretchr/testify/assert"
 
 	secscanv1alpha1 "github.com/quay/container-security-operator/apis/secscan/v1alpha1"

--- a/secscan/quay/security.go
+++ b/secscan/quay/security.go
@@ -3,7 +3,7 @@ package quay
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"path"
@@ -49,7 +49,7 @@ func (c *SecscanClient) ManifestSecurity(namespace, repository, digest string, v
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// Error reading response body
 		return nil, err
@@ -79,7 +79,7 @@ func (c *SecscanClient) ManifestSecurityFromTemplate(template, namespace, reposi
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// Error reading response body
 		return nil, err
@@ -113,7 +113,7 @@ func (c *SecscanClient) GetLayerData(image *image.Image, features, vulnerabiliti
 		return nil, fmt.Errorf("Request returned non-200 response: %s", resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// Error reading response body
 		return nil, fmt.Errorf("failed to perform request: %v", err)

--- a/secscan/quay/wellknown.go
+++ b/secscan/quay/wellknown.go
@@ -3,7 +3,7 @@ package quay
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 
@@ -43,7 +43,7 @@ func (c *WellknownClient) AppCapabilities() (*AppCapabilities, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		// Error reading response body
 		return nil, err

--- a/secscan/wellknown.go
+++ b/secscan/wellknown.go
@@ -3,7 +3,7 @@ package secscan
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -69,7 +69,7 @@ func NewWellknownClient(host, wellKnownEndpoint string) (*WellknownClient, error
 		return nil, fmt.Errorf("Request returned non-200 response: %s", resp.Status)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We add a user agent to CSO to better track CSO requests to Quay and/or other registries. User agent reported version will now depend on `QUAY_VERSION` which is added as an env. variable to CSO deployment.

Fixes https://github.com/quay/container-security-operator/issues/141.