### PR TITLE
chore: Add arm64 supported label in CSO CSV [PROJQUAY-9888]

### DIFF
--- a/bundle/manifests/container-security-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/container-security-operator.clusterserviceversion.yaml
@@ -23,6 +23,7 @@ metadata:
     operatorframework.io/arch.amd64: supported
     operatorframework.io/arch.s390x: supported
     operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/arch.arm64: supported
     operatorframework.io/os.linux: supported
 spec:
   customresourcedefinitions:


### PR DESCRIPTION
Add arm64 supported label in CSV, then openshift UI could display operator info