### PR TITLE
PROJQUAY-11621: docs: add repo context files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,18 @@ For specific topics, see:
 - @agent_docs/architecture.md - Component details, CRD structure, configuration
 - @agent_docs/development.md - Building, testing, code generation
 - @agent_docs/deployment.md - OLM deployment, container builds
+
+## Contextification Addendum
+
+Low-token routing:
+
+- Entrypoint: `cmd/`
+- CRD/API: `apis/secscan/v1alpha1/`
+- Reconciliation/labelling: `labeller/`
+- Registry security client: `secscan/`
+- Image parsing: `image/`
+- Generated clients: `generated/` (do not edit)
+
+Commands: `make build`, `make run`, `make installcrds`, `go test -v ./...`, `make codegen`.
+
+Guardrail: pod labels are summaries; full CVE details belong in `ImageManifestVuln`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,127 @@
+# container-security-operator Architecture
+
+## Purpose
+
+Display Clair vulnerability scan results in OpenShift web console.
+
+```mermaid
+flowchart LR
+    quay[Quay and Clair]
+    vuln[ImageManifestVuln CR]
+    operator[container-security-operator]
+    pods[Pods using scanned images]
+    labels[security labels]
+    console[OpenShift console]
+
+    quay --> vuln
+    vuln --> operator
+    pods --> operator
+    operator --> labels
+    labels --> pods
+    pods --> console
+```
+
+## High-Level Design
+
+```
+Clair/Quay (creates ImageManifestVuln CRs)
+    ↓
+container-security-operator (watches CRs + Pods)
+    ↓ Labels pods with vuln info
+OpenShift Console (displays security tab)
+```
+
+## Components
+
+### `/apis/secscan/v1alpha1`
+CRD definitions:
+- `ImageManifestVuln`: Vulnerability data for image manifest
+  - Severity (Critical, High, Medium, Low)
+  - CVE details
+  - Affected packages
+
+### `/cmd/manager`
+Operator entrypoint:
+- Controller manager
+- Watches ImageManifestVuln + Pod resources
+
+### `/labeller`
+Pod labeling logic:
+- Matches Pods to ImageManifestVuln by image digest
+- Adds labels: `secscan/hasVulnerabilities`, `secscan/highestSeverity`
+- Updates labels on vuln changes
+
+### `/k8sutils`
+Kubernetes client helpers:
+- Pod queries
+- Label updates
+- Event recording
+
+## Data Flow
+
+```
+1. Quay/Clair scans image → creates ImageManifestVuln CR:
+   apiVersion: secscan.quay.redhat.com/v1alpha1
+   kind: ImageManifestVuln
+   metadata:
+     name: sha256-abc123...
+   spec:
+     image: quay.io/org/app@sha256:abc123
+     manifest: sha256:abc123
+     features:
+       - name: curl
+         version: 7.68.0
+         vulnerabilities:
+           - name: CVE-2023-1234
+             severity: High
+             fixedBy: 7.68.1
+
+2. operator watches ImageManifestVuln creation
+
+3. operator queries Pods using image sha256:abc123
+
+4. operator labels matching Pods:
+   secscan/hasVulnerabilities: "true"
+   secscan/highestSeverity: "High"
+   secscan/affectedByVulns: "CVE-2023-1234,CVE-2023-5678"
+
+5. OpenShift console reads labels → displays in Security tab
+```
+
+## Labeling Strategy
+
+Pod labels:
+- `secscan/hasVulnerabilities`: "true" | "false"
+- `secscan/highestSeverity`: "Critical" | "High" | "Medium" | "Low"
+- `secscan/affectedByVulns`: comma-separated CVE list (truncated if >63 chars)
+
+## Reconciliation
+
+```
+Watch ImageManifestVuln:
+  On create/update:
+    - Extract image digest
+    - Find Pods with matching image
+    - Calculate highest severity
+    - Apply labels
+
+Watch Pods:
+  On create:
+    - Extract image digest
+    - Find ImageManifestVuln for digest
+    - Apply labels if vulns exist
+```
+
+## Performance
+
+- Indexer for image digest → ImageManifestVuln mapping
+- Batch label updates (multiple pods with same image)
+- No polling (watch-based)
+
+## OpenShift Integration
+
+Console plugin displays:
+- Vulnerability count by severity
+- CVE details with links to NVD
+- Affected packages + fixed versions
+- Drill-down from workload → vulns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to container-security-operator
+
+## Setup
+
+```bash
+# Requires OpenShift cluster with Quay integration
+make install
+make deploy
+```
+
+## Development
+
+Displays Clair vulnerability scan results in OpenShift console.
+
+Watches:
+- `ImageManifestVuln` CRs (created by Clair/Quay)
+- Pods (to link vulns to running workloads)
+
+## Testing
+
+```bash
+# Unit tests
+make test
+
+# E2E (requires OpenShift + Quay with Clair)
+make test-e2e
+```
+
+## Pull Requests
+
+- Test on OpenShift 4.x
+- Update labeller logic tests
+- Verify console UI displays correctly
+- Update CRD if adding new fields
+
+## Code Structure
+
+- `apis/secscan/v1alpha1/` - CRD types
+- `cmd/manager/` - operator entrypoint
+- `labeller/` - pod vulnerability labeling
+- `k8sutils/` - K8s client helpers
+- `bundle/` - OLM metadata

--- a/README.md
+++ b/README.md
@@ -130,3 +130,26 @@ Check if a pod has any vulnerability, and list the CVEs, if any:
 ```sh
 $ kubectl get imagemanifestvulns.secscan.quay.redhat.com --selector=<namespace>/<pod-name> -o jsonpath='{.items[*].spec.features[*].vulnerabilities[*].name}'
 ```
+
+## Contextification Addendum
+
+```mermaid
+flowchart LR
+    quay[Quay and Clair]
+    vuln[ImageManifestVuln]
+    operator[container-security-operator]
+    pods[Pods]
+    labels[security labels]
+    console[OpenShift console]
+
+    quay --> vuln
+    vuln --> operator
+    pods --> operator
+    operator --> labels
+    labels --> pods
+    pods --> console
+```
+
+Key paths: `apis/secscan/v1alpha1/`, `cmd/`, `labeller/`, `secscan/`, `image/`, `generated/`, `bundle/`, and `hack/`.
+
+Use `make build`, `make run`, `make installcrds`, `go test -v ./...`, and `make codegen`. Do not edit generated clients manually.


### PR DESCRIPTION
## Summary
Adds the required contextification docs for `container-security-operator` as part of [PROJQUAY-11621](https://redhat.atlassian.net/browse/PROJQUAY-11621).

## Changes
 - Adds `ARCHITECTURE.md` with component layout, data flow, and OpenShift integration context.
  - Adds `CONTRIBUTING.md` with setup, testing, and review guidance.
  - Updates `README.md` with a contextification addendum and architecture diagram.
  - Updates `AGENTS.md` with low-token routing for AI agents.