### PR TITLE
[redhat-3.17] NO-ISSUE: add: OLM bundle metadata for 3.17.5

### DIFF
--- a/bundle/art.yaml
+++ b/bundle/art.yaml
@@ -1,2 +1,8 @@
 ---
-updates: []
+updates:
+  - file: "manifests/container-security-operator.clusterserviceversion.yaml"
+    update_list:
+      - search: "name: container-security-operator.v1.0.6"
+        replace: "name: container-security-operator.v3.17.5"
+      - search: "version: 1.0.6"
+        replace: "version: 3.17.5"

--- a/bundle/container-security-operator.package.yaml
+++ b/bundle/container-security-operator.package.yaml
@@ -1,0 +1,6 @@
+---
+packageName: container-security-operator
+channels:
+- name: stable-3.17
+  currentCSV: container-security-operator.3.17.5
+defaultChannel: stable-3.17

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -3,7 +3,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: quay-container-security-operator-rhel9
+  - name: container-security-operator-rhel9
     from:
       kind: DockerImage
-      name: quay.io/projectquay/container-security-operator:latest
+      name: registry.redhat.io/quay/container-security-operator-rhel9

--- a/bundle/image-references
+++ b/bundle/image-references
@@ -3,7 +3,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: container-security-operator-rhel9
+  - name: quay-container-security-rhel9-operator
     from:
       kind: DockerImage
-      name: registry.redhat.io/quay/container-security-operator-rhel9
+      name: registry.redhat.io/quay/quay-container-security-rhel9-operator


### PR DESCRIPTION
Add OLM bundle metadata and configuration files for the 3.17.5 release to support ART pipeline onboarding.

Changes:
- bundle/quay-operator.package.yaml: package metadata and channel configuration
- bundle/art.yaml: upstream-to-downstream version patching rules  
- bundle/image-references: ImageStream mappings for all referenced images
- update-csv configuration for automatic CSV version patching

Related: [ART-19361](https://redhat.atlassian.net/browse/ART-19361)