### PR TITLE
fix: add name label to bundle Dockerfile for release validation (ART-19361)

### DIFF
--- a/bundle/Dockerfile
+++ b/bundle/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+LABEL name="quay/quay-container-security-operator-bundle"
 LABEL operators.operatorframework.io.bundle.channel.default.v1: stable-3.6
 LABEL operators.operatorframework.io.bundle.channels.v1: stable-3.6
 LABEL operators.operatorframework.io.bundle.manifests.v1: manifests/


### PR DESCRIPTION
Add name label to bundle Dockerfile to satisfy check-labels validation in the release pipeline.